### PR TITLE
bug: Fix broken download link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -192,4 +192,4 @@ Universal Gcode Sender is free software developed and maintained in my free time
 [github_img]: https://img.shields.io/badge/Star-123-green.svg?style=social
 [github_link]: https://github.com/winder/Universal-G-Code-Sender
 [release_img]: https://img.shields.io/github/release/winder/Universal-G-Code-Sender
-[release_link]: /download/
+[release_link]: download/


### PR DESCRIPTION
The download link used in the release badge on the main page has a
leading slash which tells mkdocs to anchor the URL against the base
domain name.

![image](https://user-images.githubusercontent.com/57542/128611912-ede4f887-6ea0-40bd-9d2c-8ce035422976.png)

This removes the initial slash from the URL, allowing mkdocs to
correctly use the same path as generated via `docs/download.md`

This was tested with the [site_url][1] configuration setting from mkdocs
to ensure that it is resillient to base path changes.

[1]: https://www.mkdocs.org/user-guide/configuration/#site_url